### PR TITLE
Accounts: shorter view part of account id's

### DIFF
--- a/dividend-tools/static/js/global.js
+++ b/dividend-tools/static/js/global.js
@@ -147,5 +147,5 @@ async function loadAccounts(mtl, mtl_city, mtl_rect) {
 
 function makeAccountUrl(id) {
   return '<a href="https://stellar.expert/explorer/public/account/' +
-    id + '">' + id.substring(0,10) + '...' + id.substr(id.length - 10) + '</a>';
+    id + '">' + id.substring(0, 6) + '...' + id.substr(id.length - 60) + '</a>';
 }

--- a/docs/js/global.js
+++ b/docs/js/global.js
@@ -147,5 +147,5 @@ async function loadAccounts(mtl, mtl_city, mtl_rect) {
 
 function makeAccountUrl(id) {
   return '<a href="https://stellar.expert/explorer/public/account/' +
-    id + '">' + id.substring(0,10) + '...' + id.substr(id.length - 10) + '</a>';
+    id + '">' + id.substring(0, 6) + '...' + id.substr(id.length - 60) + '</a>';
 }


### PR DESCRIPTION
Отображать ссылки на Stellar-адреса не по 10 символов с краёв, а по 6, как компромисс с ещё более кратким вариантом в 4 символа.